### PR TITLE
Add on-screen invalid move message

### DIFF
--- a/adapters/pygame_ui.py
+++ b/adapters/pygame_ui.py
@@ -14,6 +14,10 @@ class PygameChessUI(ChessUIService):
         self.screen = pygame.display.set_mode((TILE_SIZE*BOARD_SIZE, TILE_SIZE*BOARD_SIZE))
         pygame.display.set_caption("Chess - Hexagonal Architecture Demo")
         self.font = pygame.font.Font("dejavu-sans.book.ttf", 48)
+        # Storage for temporary on-screen messages
+        self.message = None
+        self.message_time = 0
+        self.message_duration = 0
 
     def draw_board(self, game):
         board = game.board
@@ -29,6 +33,20 @@ class PygameChessUI(ChessUIService):
                     text_rect = text_surf.get_rect(center=(col*TILE_SIZE + TILE_SIZE//2,
                                                            row*TILE_SIZE + TILE_SIZE//2))
                     self.screen.blit(text_surf, text_rect)
+
+        # If there's a message, draw it centered on the board for a short time
+        if self.message:
+            elapsed = pygame.time.get_ticks() - self.message_time
+            if elapsed < self.message_duration:
+                msg_surf = self.font.render(self.message, True, (255, 0, 0))
+                msg_rect = msg_surf.get_rect(center=(TILE_SIZE*BOARD_SIZE//2,
+                                                     TILE_SIZE*BOARD_SIZE//2))
+                bg_rect = msg_rect.inflate(20, 20)
+                pygame.draw.rect(self.screen, (255, 255, 255), bg_rect)
+                pygame.draw.rect(self.screen, (0, 0, 0), bg_rect, 2)
+                self.screen.blit(msg_surf, msg_rect)
+            else:
+                self.message = None
         pygame.display.flip()
 
     def get_player_input(self, current_player):
@@ -46,3 +64,9 @@ class PygameChessUI(ChessUIService):
                     row = y // TILE_SIZE
                     # For demonstration, let's just return a single square
                     return (row, col)
+
+    def show_message(self, message, duration=2000):
+        """Display a transient message on screen for ``duration`` milliseconds."""
+        self.message = message
+        self.message_time = pygame.time.get_ticks()
+        self.message_duration = duration

--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def main():
             try:
                 move_piece_uc.execute(game_id, selected_square, square)
             except Exception as ex:
-                print(ex)  # In a real game, show a message on screen
+                ui.show_message(str(ex))
             selected_square = None
 
         # If the game ended, you might break or show a winner screen, etc.


### PR DESCRIPTION
## Summary
- show a temporary message in `PygameChessUI`
- use the new message display when a move is invalid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b321db448325852e83ca9b860e19