### PR TITLE
Add persistent game saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The goal of this project is to demonstrate how **DDD** and **Hexagonal Architect
 - **`domain/`**: Contains the core entities (`Board`, `Piece`, `Game`), value objects, and domain services (e.g. `MovementService`).
 - **`application/`**: Contains the **use cases** or **application services** (e.g. `StartGameUseCase`, `MovePieceUseCase`).
 - **`ports/`**: Contains definitions for **interfaces** (e.g. `GameRepository`, `ChessUIService`).
-- **`adapters/`**: Contains concrete **implementations** of those interfaces (e.g. `InMemoryGameRepository`, `PygameChessUI`).
+- **`adapters/`**: Contains concrete **implementations** of those interfaces (e.g. `FileGameRepository`, `PygameChessUI`).
 - **`main.py`**: Ties everything together and starts the game loop.
 
 ---
@@ -91,7 +91,7 @@ If everything is set up correctly, you’ll see an 8×8 board with Unicode piece
 - **MovePieceUseCase** : Validates a move (via MovementService) and, if valid, updates the Game. Also checks for check/checkmate.
 ### Ports and Adapters
 - **GameRepository (port)**: Defines how we load/save a Game.
-- **InMemoryGameRepository (adapter)**: Stores games in an in-memory dictionary, identified by UUIDs.
+- **FileGameRepository (adapter)**: Stores games on disk using pickle files.
 - **ChessUIService (port)**: Defines how we draw the board and handle user input.
 - **PygameChessUI (adapter)**: Uses Pygame to draw squares, pieces, and detect mouse clicks.
 ### Pygame UI

--- a/adapters/file_game_repository.py
+++ b/adapters/file_game_repository.py
@@ -1,0 +1,31 @@
+import uuid
+import pickle
+from pathlib import Path
+from ports.game_repository import GameRepository
+
+class FileGameRepository(GameRepository):
+    """Persist games to disk using pickle serialization."""
+    def __init__(self, directory="saved_games"):
+        self.directory = Path(directory)
+        self.directory.mkdir(exist_ok=True)
+
+    def save(self, game):
+        game_id = getattr(game, 'id', None)
+        if not game_id:
+            game_id = str(uuid.uuid4())
+            setattr(game, 'id', game_id)
+        file_path = self.directory / f"{game_id}.pkl"
+        with open(file_path, 'wb') as f:
+            pickle.dump(game, f)
+        return game_id
+
+    def find_by_id(self, game_id):
+        file_path = self.directory / f"{game_id}.pkl"
+        if not file_path.exists():
+            return None
+        with open(file_path, 'rb') as f:
+            game = pickle.load(f)
+        return game
+
+    def list_game_ids(self):
+        return [p.stem for p in self.directory.glob('*.pkl')]

--- a/adapters/in_memory_game_repository.py
+++ b/adapters/in_memory_game_repository.py
@@ -16,3 +16,6 @@ class InMemoryGameRepository(GameRepository):
 
     def find_by_id(self, game_id):
         return self.storage.get(game_id, None)
+
+    def list_game_ids(self):
+        return list(self.storage.keys())

--- a/main.py
+++ b/main.py
@@ -1,19 +1,29 @@
-from adapters.in_memory_game_repository import InMemoryGameRepository
+from adapters.file_game_repository import FileGameRepository
 from adapters.pygame_ui import PygameChessUI
 from application.use_cases import StartGameUseCase, MovePieceUseCase
 from domain.services import MovementService
 
 def main():
     # Setup
-    game_repository = InMemoryGameRepository()
+    game_repository = FileGameRepository()
     movement_service = MovementService()
     ui = PygameChessUI()
 
     start_game_uc = StartGameUseCase(game_repository)
     move_piece_uc = MovePieceUseCase(game_repository, movement_service)
 
-    # Create a new game
-    game_id = start_game_uc.execute()
+    game_id = None
+    saved_games = game_repository.list_game_ids()
+    if saved_games:
+        print("Saved games:")
+        for idx, gid in enumerate(saved_games, 1):
+            print(f"{idx}. {gid}")
+        choice = input("Select game number to load or press Enter for new game: ")
+        if choice.isdigit() and 1 <= int(choice) <= len(saved_games):
+            game_id = saved_games[int(choice)-1]
+
+    if not game_id:
+        game_id = start_game_uc.execute()
 
     running = True
     selected_square = None

--- a/ports/game_repository.py
+++ b/ports/game_repository.py
@@ -8,3 +8,8 @@ class GameRepository(ABC):
     @abstractmethod
     def find_by_id(self, game_id):
         pass
+
+    @abstractmethod
+    def list_game_ids(self):
+        """Return a list of saved game IDs."""
+        pass


### PR DESCRIPTION
## Summary
- create `FileGameRepository` to persist games to disk
- extend `GameRepository` port with `list_game_ids`
- update in-memory repo with new method
- prompt user to load an existing game or start new one in `main.py`
- update README references to new repository

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b9995e9483258a5eea12cee0daa6