### PR TITLE
Filter pkg_resources warning from pygame

### DIFF
--- a/adapters/pygame_ui.py
+++ b/adapters/pygame_ui.py
@@ -1,5 +1,14 @@
-import pygame
+"""Pygame-based UI implementation."""
+
+import os
 import sys
+import warnings
+
+# Hide the pygame community message and silence pkg_resources deprecation
+os.environ.setdefault("PYGAME_HIDE_SUPPORT_PROMPT", "1")
+warnings.filterwarnings("ignore", category=UserWarning, module="pygame.pkgdata")
+
+import pygame
 from ports.ui_service import ChessUIService
 
 TILE_SIZE = 80


### PR DESCRIPTION
## Summary
- hide Pygame's support prompt
- silence pkg_resources deprecation warning emitted by pygame

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68784caf4f888325af0557246c99b0d7